### PR TITLE
[site/plugins,#96]: support for (obsidian) wiki links syntax

### DIFF
--- a/site/content/test.md
+++ b/site/content/test.md
@@ -1,4 +1,30 @@
-# Test page for video embed links in markdown
+# Test (Obsidian) wiki link syntax
+
+1. Internal link  
+    *`[[recent-events]]`*  
+	[[recent-events]]
+
+2. Internal link with custom divider  
+	*`[[are-crypto-tokens-securities|Crypto]]`*  
+	[[are-crypto-tokens-securities|Crypto]]
+
+3. Internal link with heading  
+     *`[[about#Making Sense of Web3]]`*  
+	[[about#Making Sense of Web3]]
+
+4. Internal link with heading and custom divider  
+	 *`[[webinars#Upcoming|Upcoming webinars]]`*  
+	[[webinars#Upcoming|Upcoming webinars]]
+
+5. Internal link heading within page  
+     *`[[#Our Approach]]`*  
+	[[#Our Approach]]
+
+
+***
+
+# Test video embed links in markdown
+
 This youtube link (https://www.youtube.com/embed/K5JtPTyc0y0) surrounded by newlines in markdown would display as follows:
 
 https://www.youtube.com/embed/K5JtPTyc0y0
@@ -8,3 +34,8 @@ For eg .. Links without being surrounded by newlines will show as below:
 * Youtube:  https://www.youtube.com/watch?v=z2uAg-AIs-Y
 * Podcast: https://anchor.fm/life-itself/episodes/Are-Cryptocurrencies-Securities--The-Nature-of-Securities--Their-Relation-to-Crypto-Tokens-with-Stephen-Diehl-e1fph69
 * Wiki topic:  [Securities Framework](../concepts/security.md)
+
+***
+
+## Our Approach
+We intend to take a distinctive approach.

--- a/site/contentlayer.config.ts
+++ b/site/contentlayer.config.ts
@@ -1,6 +1,9 @@
 import { defineDocumentType, makeSource } from 'contentlayer/source-files'
 // import readingTime from 'reading-time'
 import remarkGfm from 'remark-gfm';
+import rehypeSlug from 'rehype-slug'
+import rehypeAutolinkHeadings from 'rehype-autolink-headings'
+import wikiLinkPlugin from "remark-wiki-link-plus"
 
 const OtherPage = defineDocumentType(() => ({
   name: 'OtherPage',
@@ -18,6 +21,10 @@ export default makeSource({
   contentDirPath: 'content',
   documentTypes: [OtherPage],
   mdx: {
-    remarkPlugins: [remarkGfm],
+    remarkPlugins: [
+      remarkGfm,
+      [wikiLinkPlugin, { markdownFolder: 'content' }]
+    ],
+    rehypePlugins: [rehypeSlug, rehypeAutolinkHeadings]
   }
 })

--- a/site/package.json
+++ b/site/package.json
@@ -23,9 +23,12 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-player": "^2.10.0",
+    "rehype-autolink-headings": "^6.1.1",
+    "rehype-slug": "^5.0.1",
     "remark-gfm": "^3.0.0",
     "remark-slug": "^7.0.0",
-    "remark-toc": "^8.0.0"
+    "remark-toc": "^8.0.0",
+    "remark-wiki-link-plus": "^1.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.2.6",


### PR DESCRIPTION
### Support (Obsidian) wiki link syntax in publishing to website

Also resolves #99 

This PR includes support for:

using remark-wiki-link-plus plugin - https://github.com/life-itself/remark-wiki-link-plus
- [x] [[Internal link]]
- [x] [[Internal link|With custom text]]
- [x] [[Internal link#heading]
- [x] [[Internal link#heading|With custom text]]
- [x] [[#heading]] (for headings on the same page)

using https://github.com/rehypejs/rehype-autolink-headings & https://github.com/rehypejs/rehype-slug
- [x] anchor links to headings

Testing in development mode:
- Open obsidian with web3 folder/vault
- npm run dev
- add wiki links in any obsidian file and see live changes in markdown and page

An example of the above can be found at /test page.