### PR TITLE
Remove redundant 'are' in the list of claims.

### DIFF
--- a/claims/index.md
+++ b/claims/index.md
@@ -21,7 +21,7 @@ Explore crypto and "web3" in terms of the claims made about it. These subclaims 
 * [Are crypto assets a form of predatory inclusion?](/claims/is-predatory.md)
 * [Is crypto a solution for the unbanked?](/claims/is-crypto-unbanked.md)
 * [Is crypto providing faster payment rails or better remittance services?](/claims/is-better-payments.md)
-* [Are NFTs are good for artists?](/claims/is-nfts-artists.md)
+* [Are NFTs good for artists?](/claims/is-nfts-artists.md)
 * [What is the narrative economics of crypto assets?](/claims/is-narrative-economics.md)
 * [Are crypto assets legal?](/claims/is-legal.md)
 * [Are crypto tokens a negative-sum investment?](/claims/is-negative-sum.md)


### PR DESCRIPTION
Please excuse the slightly low-effort PR, but since I've now seen it, this is bugging me more than I want to admit. :)