### PR TITLE
[site/pages]: index page for all "wiki pages" / content

### DIFF
--- a/site/pages/all.js
+++ b/site/pages/all.js
@@ -1,0 +1,52 @@
+import { NextSeo } from "next-seo";
+import { allOtherPages } from "contentlayer/generated";
+
+export default function All({ pages }) {
+  const labels = new Set(pages.map((p) => p.wikiPage.charAt(0)));
+  return (
+    <>
+      <NextSeo title="All pages" />
+      <div className="prose dark:prose-invert pt-6 mx-4 md:mx-auto">
+        <h1>A-Z Index</h1>
+        {Array.from(labels).map((pageTitle) => (
+          <div key={pageTitle} className="ml-2 pt-2">
+            <h3>{pageTitle}</h3>
+            <hr className="m-0 w-full" />
+            <ul className="list-disc flex flex-wrap">
+              {pages.map(
+                ({ wikiPage, wikiPath }) =>
+                  pageTitle === wikiPage.charAt(0) && (
+                    <li key={wikiPath} className="pr-8 w-fit">
+                      <a href={wikiPath}>{wikiPage}</a>
+                    </li>
+                  )
+              )}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+export async function getStaticProps() {
+  const pages = allOtherPages
+    .map((page) => {
+      const wikiPath = page._raw.flattenedPath;
+      const wikiPage = wikiPath
+        .split("/")
+        .pop()
+        .replace(/-/g, " ")
+        .replace(
+          /^(\w)(.+)/,
+          (match, p1, p2) => p1.toUpperCase() + p2.toLowerCase()
+        );
+
+      return { wikiPage, wikiPath };
+    })
+    .sort((a, b) => a.wikiPage.localeCompare(b.wikiPage));
+
+  return {
+    props: { pages },
+  };
+}


### PR DESCRIPTION
This PR completes one of the tasks in #94 

Currently this is a list of links to all available pages in the content folder (i.e., all markdown pages), are alphabetically sorted and are under their respective alphabet labels.

Tasks:
- [x] Create index page for all content
- [x] page url at `/all/`