### PR TITLE
[site/links]: add support for next links in markdown

### DIFF
--- a/site/components/Anchor.js
+++ b/site/components/Anchor.js
@@ -1,5 +1,6 @@
+import { useEffect, useState } from "react"
+import Link from 'next/link';
 import { Tooltip } from './Tooltip';
-
 /**
  * Component for adding previews on hovering over anchor tags with relative paths
  */
@@ -8,17 +9,44 @@ export const Anchor = (props) => {
   const pathIsRelative = (path) => {
     return path &&
       path.indexOf("http:") !== 0 &&
-      path.indexOf("https:") !== 0 &&
-      path.indexOf("#") !== 0
+      path.indexOf("https:") !== 0
   }
 
-  if (pathIsRelative(props.href)) {
+  const href = props.href.endsWith(".md")
+    ? props.href.replace(".md", "")
+    : props.href;
+
+  const [ path, setPath ] = useState(href)
+
+  useEffect(() => {
+    let isMount = true
+    if (isMount) {
+      const link = document.createElement("a")
+      link.href = href
+      setPath(link.pathname)
+    }
+    return () => {
+      setPath(href)
+      isMount = false
+    }
+  },[])
+
+  if (pathIsRelative(href)) {
+    if (href.indexOf("#") !== 0) {
+      return (
+        <Tooltip {...props} href={href} render={ tooltipTriggerProps => (
+          <Link href={path}>
+            <a {...tooltipTriggerProps} href={path} />
+          </Link>
+        )}
+        />
+      )
+    }
     return (
-      <Tooltip {...props} render={ tooltipTriggerProps => (
-        <a {...tooltipTriggerProps} />
-      )}
-      />
+      <Link href={href}>
+        <a {...props} />
+      </Link>
     )
   }
-  return <a {...props} />;
+  return <a target="_blank" rel="noopener" {...props} />;
 };

--- a/site/components/Tooltip.js
+++ b/site/components/Tooltip.js
@@ -117,7 +117,7 @@ export const Tooltip = ({ render, ...props }) => {
       if (filePath.includes('notes')) {
         return
       }
-      const page = allOtherPages.find(p => p._raw.sourceFilePath === filePath)
+      const page = allOtherPages.find(p => p._raw.flattenedPath === filePath)
       content = documentExtract(page.body.raw);
     } catch {
       return


### PR DESCRIPTION
## Add support for next links (internal links) in markdown

Resolves #170 
***

This PR adds support for next links ie, `<Link href="..." />` in markdown to handle site's internal links. Also, external links will be open in a new tab. And finally, links that end with `.md` are replaced with path only.

### Tasks:

- [x] Handle hrefs ending with `.md`
- [x] Add internal links check for heading and tooltips to handle accordingly
- [x] Handle external links to open in new tabs
- [x] Change source file path based on href above in tooltip component