### PR TITLE
split into subclaims, added front matter

### DIFF
--- a/claims/is-better-payments.md
+++ b/claims/is-better-payments.md
@@ -1,12 +1,33 @@
-# Is crypto providing faster payment rails or better remittance services?
+---
+title: Crypto will provide cheaper, faster payment and remittance services
+description: The claim being made here is that a) 
+cheaper and faster payment and remittance services are desirable, b) crypto can provide this, and c) the benefits of this would outway any negative externalities. We find this claim to fail on points b) and c) and to therefore be false.
+category:
+  - claim: y
+  - featured: y 
+  - interview: n
+  - deepdive: n
+claim:
+  - evaluation: NN
+  - confidence: HH
 
 ## Claim Steel-Manned
 
-Crypto can provide us with better payment rails i.e. a better Visa, Stripe etc. These payment rails would have reduced friction and costs resulting in a cheaper, faster, more efficient service. 
+### Subclaim 1: Crypto can provide payment and remittance services by virtue of fulfilling the fuctions of a currency.
 
-Blockchain-based payment rails can also facilitate faster, cheaper, and more efficient international remittances. People can send money abroad, eg from US dollars to Indian rupees using crypto.
+Payment systems and remittance services need to pay in something. That something must either be a [currency](../concepts/currency.md) (eg dollars) or a [commodity](../concepts/commodity.md) (eg cows).
+
+Crypto can provide payment systems and remittance services because it serves the three functions of a currency:
+1. It can be a unit of account in that it’s a standard and divisible unit of measurement of market value (i.e. it can be used to signal what something is worth).
+2. It can be a medium of exchange in that we can use it as an intermediary instrument to transact for goods and services.
+3. It can act as a [store of value](../concepts/store-of-value.md) in that it (at least ideally) retains its purchasing power over time, such that we can retrieve the value of our investment at a later date without making a significant loss.
+
+### Subclaim 2: Crypto can provide *better* payment rails and remittance services
+
+Crypto can provide us with better payment rails - i.e. a better Visa, Stripe etc - and more efficient international remittances - I can send money abroad, eg from US dollars to Indian rupees using crypto. These blockchain-based payment rails would have reduced friction and costs resulting in a cheaper, faster, more efficient service. 
 
 ## Examples of the claim being made
+
 [BLOCKDATA. ‘Blockchain Is Disrupting the $700 Billion Remittance Industry’. Medium (blog), 7 March 2019.](https://medium.com/@blockdata_tech/blockchain-is-disrupting-the-700-billion-remittance-industry-b79a01a95a10.) 
 
 [CMT, Bill Miller IV, CFA. ‘The Value Investor’s Case for... Bitcoin?!’ _Miller Value Partners_ (blog), 8 September 2015:]([https://millervalue.com/a-value-investors-case-for-bitcoin/](https://millervalue.com/a-value-investors-case-for-bitcoin/)
@@ -19,11 +40,25 @@ Roger Ver, an investor in Blockchain.info, quoted in [COINTELEGRAPH. ‘Western 
  
 ## Evaluation: False (high confidence)
 
-Since crypto assets [cannot function as a currency](is-bitcoin-currency.md), they are not useful in building payment rails or remittance services. Crypto assets can be used as an intermediate asset in which trades can be settled in, but this does not serve a technical of financial purpose; it simply introduces an unnecessary conversion step.
+### Subclaim 1: Crypto *cannot* fulfil the fuctions of a currency.
+
+Crypto assets are [not currencies](is-bitcoin-currency.md) because they cannot fulfil the definition of [money](../concepts/money.md).
+
+Crypto assets cannot function as a medium of exchange. The transaction throughput is so small that they don't work as a global system of currency - they can't process transactions fast enough. This is inherent to the proof-of-work process crypto assets use to verify their transactions. This incapacity is therefore baked in.
+
+ Crypto assets also do not appear to hold potential as a store of value given their extremely high price variance. If they were to behave as a [store of value](../concepts/store-of-value.md), they would have to abandon hypervolatility, and there is no easily identifiable economic mechanism for this to happen.  
+
+### Subclaim 2: Crypto can provide *better* payment rails and remittance services
+
+Since crypto assets cannot function as a currency, they are not useful in building payment rails or remittance services. Crypto assets can be used as an intermediate asset in which trades can be settled in, but this does not serve a technical of financial purpose; it simply introduces an unnecessary conversion step.
 
 If a person wants to send money abroad, say from US dollars to Indian rupees, they would typically use a service like MoneyGram or WesternUnion. These services charge a transaction fee and do a direct swap of dollars to rupees from the reserves the company holds in both currencies.
 
 If one postulates using a crypto asset or stablecoin as a means to do remittances then they are still faced with the *last leg problem*. Their relative in India still has to convert the crypto asset into the local currency to buy domestic goods and services since supermakets and stores don't accept crypto assets. So instead of a dollar-to-ruppee conversion we would hypothetically do a dollar-to-bitcoin-to-rupee conversion. This introduces [price-risk](../concepts/price-risk.md), [counterparty-risk](../concepts/counterparty-risk.md) and unnecessary conversion fees to accommodate the extraneous third exchange. This adds unnecessary complexity and is likely more expensive.
+
+In addition, if crypto were to provide *cheaper* and *faster* payment rails, it’s likely this will have been acheived not via technological advancements, but by removing safeguards. 
+
+The costs present in most retail financial services have very little to do with the technology. Transaction costs associated with payments are fraud mitigation, transaction reversal, custodial services, customer service, and compliance. Customers want these safeguards. Once we add compliance back to crypto payment rails, it’s unclear that there would be any efficiency increase or cost savings.
 
 See industry analysts describe this proble in more depth: [Does Bitcoin/Blockchain make sense for international money transfers?](https://www.saveonsend.com/bitcoin-blockchain-money-transfer/)
 

--- a/claims/is-better-payments.md
+++ b/claims/is-better-payments.md
@@ -1,7 +1,7 @@
 ---
-title: Crypto will provide cheaper, faster payment and remittance services
-description: The claim being made here is that a) 
-cheaper and faster payment and remittance services are desirable, b) crypto can provide this, and c) the benefits of this would outway any negative externalities. We find this claim to fail on points b) and c) and to therefore be false.
+title: "Crypto will provide cheaper, faster payment and remittance services"
+description: "The claim being made here is that a. 
+cheaper and faster payment and remittance services are desirable, b. crypto can provide this, and c. the benefits of this would outway any negative externalities. We find this claim to fail on points b. and c. and to therefore be false."
 category:
   - claim: y
   - featured: y 
@@ -10,6 +10,7 @@ category:
 claim:
   - evaluation: NN
   - confidence: HH
+---
 
 ## Claim Steel-Manned
 

--- a/claims/is-better-payments.md
+++ b/claims/is-better-payments.md
@@ -1,7 +1,6 @@
 ---
-title: "Crypto will provide cheaper, faster payment and remittance services"
-description: "The claim being made here is that a. 
-cheaper and faster payment and remittance services are desirable, b. crypto can provide this, and c. the benefits of this would outway any negative externalities. We find this claim to fail on points b. and c. and to therefore be false."
+title: Crypto will provide cheaper, faster payment and remittance services
+description: The claim being made here is that a. cheaper and faster payment and remittance services are desirable, b. crypto can provide this, and c. the benefits of this would outway any negative externalities. We find this claim to fail on points b. and c. and to therefore be false.
 category:
   - claim: y
   - featured: y 
@@ -29,15 +28,15 @@ Crypto can provide us with better payment rails - i.e. a better Visa, Stripe etc
 
 ## Examples of the claim being made
 
-[BLOCKDATA. ‘Blockchain Is Disrupting the $700 Billion Remittance Industry’. Medium (blog), 7 March 2019.](https://medium.com/@blockdata_tech/blockchain-is-disrupting-the-700-billion-remittance-industry-b79a01a95a10.) 
+BLOCKDATA (2019) ‘Blockchain is disrupting the $700 billion remittance industry’, _Medium_, 7 March. Available at: [https://medium.com/@blockdata_tech/blockchain-is-disrupting-the-700-billion-remittance-industry-b79a01a95a10](https://medium.com/@blockdata_tech/blockchain-is-disrupting-the-700-billion-remittance-industry-b79a01a95a10) (Accessed: 13 September 2022).
 
-[CMT, Bill Miller IV, CFA. ‘The Value Investor’s Case for... Bitcoin?!’ _Miller Value Partners_ (blog), 8 September 2015:]([https://millervalue.com/a-value-investors-case-for-bitcoin/](https://millervalue.com/a-value-investors-case-for-bitcoin/)
+CMT, B.M.I., CFA (2015) ‘The Value Investor’s Case for... Bitcoin?!’, _Miller Value Partners_, 8 September. Available at: [https://millervalue.com/a-value-investors-case-for-bitcoin/](https://millervalue.com/a-value-investors-case-for-bitcoin/) (Accessed: 13 September 2022):
 > The open ledger combined with the complexity of transaction data makes Bitcoin a very secure method of payment... One of Bitcoin’s biggest advantages over other payment networks like Visa (V) and MasterCard (MA) is minimal transactions fees. While other payments networks typically charge the greater of ~3% and $0.15, Bitcoin’s transaction fee tends to be a negligible fraction of the transaction, if any at all. Lower transaction fees not only enable buyers and sellers to transact at prices that are better for both parties, but they could enable micropayments in markets that are not otherwise compatible with a $0.15 surcharge on low-price, low-margin goods and services.
 
-[Nakamoto, Satoshi. ‘Bitcoin: A Peer-to-Peer Electronic Cash System’, n.d.](https://www.ussc.gov/sites/default/files/pdf/training/annual-national-training-seminar/2018/Emerging_Tech_Bitcoin_Crypto.pdf)
-
-Roger Ver, an investor in Blockchain.info, quoted in [COINTELEGRAPH. ‘Western Union Is Not yet Ready for Bitcoin International Transfer’. Cointelegraph, 1 November 2013:](https://cointelegraph.com/news/western_union_is_not_yet_ready_for_bitcoin_international_transfer)
+Ver, Roger. quoted in COINTELEGRAPH (2013) _Western Union is not yet ready for bitcoin international transfer_, _Cointelegraph_. Available at: [https://cointelegraph.com/news/western_union_is_not_yet_ready_for_bitcoin_international_transfer](https://cointelegraph.com/news/western_union_is_not_yet_ready_for_bitcoin_international_transfer) (Accessed: 13 September 2022):
 > I think we will know when bitcoin has reached prime time when it is transferring more value each day than Western Union or Money Gram... I think we may see that happen within another two years.
+
+Nakamoto, S. (no date) *Bitcoin: A Peer-to-Peer Electronic Cash System*. Available at: https://www.ussc.gov/sites/default/files/pdf/training/annual-national-training-seminar/2018/Emerging_Tech_Bitcoin_Crypto.pdf 
  
 ## Evaluation: False (high confidence)
 
@@ -64,15 +63,27 @@ The costs present in most retail financial services have very little to do with 
 See industry analysts describe this proble in more depth: [Does Bitcoin/Blockchain make sense for international money transfers?](https://www.saveonsend.com/bitcoin-blockchain-money-transfer/)
 
 ## References
-1. Plant, Luke. 2022. ‘The Technological Case against Bitcoin and Blockchain’. Luke Plant’s Home Page. 5 March 2022. https://lukeplant.me.uk/blog/posts/the-technological-case-against-bitcoin-and-blockchain/.
-1. White, Molly. 2022a. ‘Blockchain-Based Systems Are Not What They Say They Are’. Molly White (blog). 9 January 2022. https://blog.mollywhite.net/blockchains-are-not-what-they-say/.
-1. ———. 2022b. ‘Anonymous Cryptocurrency Wallets Are Not So Simple’. Molly White (blog). 12 February 2022. https://blog.mollywhite.net/anonymous-crypto-wallets/.
-1. ———. 2022c. ‘Cryptocurrency Off-Ramps, and the Shift towards Centralization’. Molly White. 12 February 2022. https://blog.mollywhite.net/off-ramps/.
-1. ———. 2022d. ‘Cryptocurrency’s Robinhood Effect’. Molly White. 17 February 2022. https://blog.mollywhite.net/cryptocurrencys-robinhood-effect/.
-1. Cembalest, Michael. 2022. ‘The Maltese Falcoin: On Cryptocurrencies and Blockchains’. https://privatebank.jpmorgan.com/content/dam/jpm-wm-aem/global/pb/en/insights/eye-on-the-market/the-maltese-falcoin.pdf.
-1. Weaver, Nicholas. 2018. Blockchains and Cryptocurrencies: Burn It With Fire. Berkeley School of Information. https://www.youtube.com/watch?v=xCHab0dNnj4.
-1. Steele, Graham. 2021. ‘The Miner of Last Resort: Digital Currency, Shadow Money and the Role of the Central Bank’. Technology and Government, Emerald Studies in Media and Communications, Forthcoming.
-1. Amato, Massimo, and Luca Fantacci. 2020. A Fistful of Bitcoins: The Risks and Opportunities of Virtual Currencies. Bocconi University Press. https://www.egeaeditore.it/ita/prodotti/economia/a-fistful-of-bitcoins.aspx.
-1. Krugman, Paul. 2018. ‘Transaction Costs and Tethers: Why I’m a Crypto Skeptic’. The New York Times 21.
-1. ———. 2021. ‘Technobabble, Libertarian Derp and Bitcoin’. The New York Times 21.
-1. Stinchcombe, Kai. 2017. ‘Ten Years In, Nobody Has Come Up With a Use for Blockchain’. Hackernoon. 22 December 2017. https://hackernoon.com/ten-years-in-nobody-has-come-up-with-a-use-case-for-blockchain-ee98c180100.
+
+Amato, M. and Fantacci, L. (2020) _A Fistful of Bitcoins: The Risks and Opportunities of Virtual Currencies_. Bocconi University Press. Available at: [https://www.egeaeditore.it/ita/prodotti/economia/a-fistful-of-bitcoins.aspx](https://www.egeaeditore.it/ita/prodotti/economia/a-fistful-of-bitcoins.aspx).
+
+_Blockchains and Cryptocurrencies: Burn It With Fire_ (2018). Berkeley School of Information. Available at: [https://www.youtube.com/watch?v=xCHab0dNnj4](https://www.youtube.com/watch?v=xCHab0dNnj4) (Accessed: 25 February 2022).
+
+Cembalest, M. (2022) _The Maltese Falcoin: On Cryptocurrencies and Blockchains_, p. 31. Available at: [https://privatebank.jpmorgan.com/content/dam/jpm-wm-aem/global/pb/en/insights/eye-on-the-market/the-maltese-falcoin.pdf](https://privatebank.jpmorgan.com/content/dam/jpm-wm-aem/global/pb/en/insights/eye-on-the-market/the-maltese-falcoin.pdf).
+
+Krugman, P. (2018) ‘Transaction costs and tethers: Why I’m a crypto skeptic’, _The New York Times_, 21.
+
+Krugman, P. (2021) ‘Technobabble, Libertarian Derp and Bitcoin’, _The New York Times_, 21. Available at: [https://www.nytimes.com/2021/05/20/opinion/cryptocurrency-bitcoin.html](https://www.nytimes.com/2021/05/20/opinion/cryptocurrency-bitcoin.html).
+
+Plant, L. (2022) _The technological case against Bitcoin and blockchain_, _Luke Plant’s home page_. Available at: [https://lukeplant.me.uk/blog/posts/the-technological-case-against-bitcoin-and-blockchain/](https://lukeplant.me.uk/blog/posts/the-technological-case-against-bitcoin-and-blockchain/) (Accessed: 6 March 2022).
+
+Steele, G. (2021) ‘The Miner of Last Resort: Digital Currency, Shadow Money and the Role of the Central Bank’, _Technology and Government, Emerald Studies in Media and Communications, Forthcoming_ [Preprint].
+
+Stinchcombe, K. (2017) _Ten Years In, Nobody Has Come Up With a Use for Blockchain_, _Hackernoon_. Available at: [https://hackernoon.com/ten-years-in-nobody-has-come-up-with-a-use-case-for-blockchain-ee98c180100](https://hackernoon.com/ten-years-in-nobody-has-come-up-with-a-use-case-for-blockchain-ee98c180100) (Accessed: 25 February 2022).
+
+White, M. (2022a) ‘Anonymous Cryptocurrency Wallets Are Not So Simple’, _Molly White_, 12 February. Available at: [https://blog.mollywhite.net/anonymous-crypto-wallets/](https://blog.mollywhite.net/anonymous-crypto-wallets/) (Accessed: 25 February 2022).
+
+White, M. (2022b) ‘Blockchain-based Systems Are Not What They Say They Are’, _Molly White_, 9 January. Available at: [https://blog.mollywhite.net/blockchains-are-not-what-they-say/](https://blog.mollywhite.net/blockchains-are-not-what-they-say/) (Accessed: 25 February 2022).
+
+White, M. (2022c) _Cryptocurrency off-ramps, and the shift towards centralization_, _Molly White_. Available at: [https://blog.mollywhite.net/off-ramps/](https://blog.mollywhite.net/off-ramps/) (Accessed: 25 February 2022).
+
+White, M. (2022d) _Cryptocurrency’s Robinhood effect_, _Molly White_. Available at: [https://blog.mollywhite.net/cryptocurrencys-robinhood-effect/](https://blog.mollywhite.net/cryptocurrencys-robinhood-effect/) (Accessed: 25 February 2022).


### PR DESCRIPTION
Having reviewed comments, I have:
- changed the title into a statement (not question)
- used the standardized front matter
- split the claim into subclaims (steel man & evaluation).
Have not yet defined payment services and remittances. Thought they might be best done in their own concept pages (so user can hover over and get definition, without definition breaking flow of text). If not, can add the definitions into the text. 
Used the standard structure to inform the description. I quite like they way I've done it - think it's very clear and a good summation of the claim and our evaluation. Feedback would be good so I know whether to do the others like this. 